### PR TITLE
 Add basic _Atomic and __auto_type support 

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -2,11 +2,11 @@ S src/
 S src/ext/
 S src/ext/pta/
 S src/frontc/
-S ocamlutil/
+S src/ocamlutil/
 B _build/
 B _build/src/
 B _build/src/ext/
 B _build/src/ext/pta/
 B _build/src/frontc/
-B _build/ocamlutil/
+B _build/src/ocamlutil/
 PKG findlib

--- a/src/frontc/cabs.ml
+++ b/src/frontc/cabs.ml
@@ -87,6 +87,7 @@ type typeSpecifier = (* Merge all specifiers into one type *)
   | Tenum of string * enum_item list option * attribute list
   | TtypeofE of expression                      (* GCC __typeof__ *)
   | TtypeofT of specifier * decl_type       (* GCC __typeof__ *)
+  | Tautotype                               (* GCC __auto_type *)
 
 and storage =
     NO_STORAGE | AUTO | STATIC | EXTERN | REGISTER
@@ -95,7 +96,7 @@ and funspec =
     INLINE | VIRTUAL | EXPLICIT
 
 and cvspec =
-    CV_CONST | CV_VOLATILE | CV_RESTRICT
+    CV_CONST | CV_VOLATILE | CV_RESTRICT | CV_ATOMIC
 
 (* Type specifier elements. These appear at the start of a declaration *)
 (* Everywhere they appear in this file, they appear as a 'spec_elem list', *)

--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -2572,8 +2572,6 @@ let rec doSpecList (suggestedAnonName: string) (* This string will be part of
     | [A.Tint64] -> TInt(ILongLong, [])
     | [A.Tsigned; A.Tint64] -> TInt(ILongLong, [])
 
-    | [A.Tunsigned; A.Tint64] -> TInt(IULongLong, [])
-    
     (* __int128 is an optional extension, but we support it *)
     | [A.Tint128] -> TInt(IInt128, [])
     | [A.Tsigned; A.Tint128] -> TInt(IInt128, [])
@@ -2801,6 +2799,7 @@ and convertCVtoAttr (src: A.cvspec list) : A.attribute list =
   | CV_CONST    :: tl -> ("const",[])    :: (convertCVtoAttr tl)
   | CV_VOLATILE :: tl -> ("volatile",[]) :: (convertCVtoAttr tl)
   | CV_RESTRICT :: tl -> ("restrict",[]) :: (convertCVtoAttr tl)
+  | CV_ATOMIC   :: tl -> ("_Atomic",[])  :: (convertCVtoAttr tl)
 
 
 and makeVarInfoCabs 
@@ -5837,6 +5836,10 @@ and doDecl (isglobal: bool) : A.definition -> chunk = function
         match nl with 
           [] -> ""
         | ((n, _, _, _), _) :: _ -> n
+      in
+      let s = match (s, nl) with
+      | ([SpecType Tautotype], [(_, SINGLE_INIT e)]) -> [SpecType (TtypeofE e)]
+      | _ -> s
       in
       let spec_res = doSpecList sugg s in
       (* Do all the variables and concatenate the resulting statements *)

--- a/src/frontc/clexer.mll
+++ b/src/frontc/clexer.mll
@@ -206,6 +206,8 @@ let init_lexicon _ =
       (**** MS VC ***)
       ("__int64", fun _ -> INT64 (currentLoc ()));
       ("__int32", fun loc -> INT loc);
+      ("_Atomic", fun loc -> ATOMIC loc);
+      ("__auto_type", fun loc -> AUTOTYPE loc);
       ("_cdecl",  fun _ -> MSATTR ("_cdecl", currentLoc ())); 
       ("__cdecl", fun _ -> MSATTR ("__cdecl", currentLoc ()));
       ("_stdcall", fun _ -> MSATTR ("_stdcall", currentLoc ())); 

--- a/src/frontc/cparser.mly
+++ b/src/frontc/cparser.mly
@@ -1542,7 +1542,11 @@ asmopname:
 
 asmclobber:
     /* empty */                         { [] }
-| COLON asmcloberlst_ne                 { $2 }
+| COLON asmcloberlst                    { $2 }
+;
+asmcloberlst:
+    /* empty */                         { [] }
+| asmcloberlst_ne                       { $1 }
 ;
 asmcloberlst_ne:
    one_string_constant                           { [$1] }

--- a/src/frontc/cparser.mly
+++ b/src/frontc/cparser.mly
@@ -261,7 +261,7 @@ let transformOffsetOf (speclist, dtype) member =
 %token<Cabs.cabsloc> ENUM STRUCT TYPEDEF UNION
 %token<Cabs.cabsloc> SIGNED UNSIGNED LONG SHORT COMPLEX
 %token<Cabs.cabsloc> VOLATILE EXTERN STATIC CONST RESTRICT AUTO REGISTER
-%token<Cabs.cabsloc> THREAD
+%token<Cabs.cabsloc> THREAD ATOMIC AUTOTYPE
 
 %token<Cabs.cabsloc> SIZEOF ALIGNOF
 
@@ -327,7 +327,7 @@ let transformOffsetOf (speclist, dtype) member =
 %left	INF SUP INF_EQ SUP_EQ
 %left	INF_INF SUP_SUP
 %left	PLUS MINUS
-%left	STAR SLASH PERCENT CONST RESTRICT VOLATILE
+%left	STAR SLASH PERCENT CONST RESTRICT VOLATILE ATOMIC
 %right	EXCLAM TILDE PLUS_PLUS MINUS_MINUS CAST RPAREN ADDROF SIZEOF ALIGNOF
 %left 	LBRACKET
 %left	DOT ARROW LPAREN LBRACE
@@ -1031,6 +1031,7 @@ type_spec:   /* ISO 6.7.2 */
 |   TYPEOF LPAREN expression RPAREN     { TtypeofE (fst $3), $1 }
 |   TYPEOF LPAREN type_name RPAREN      { let s, d = $3 in
                                           TtypeofT (s, d), $1 }
+|   AUTOTYPE        { Tautotype, $1 }
 ;
 struct_decl_list: /* (* ISO 6.7.2. Except that we allow empty structs. We 
                       * also allow missing field names. *)
@@ -1294,6 +1295,7 @@ cvspec:
     CONST                               { SpecCV(CV_CONST), $1 }
 |   VOLATILE                            { SpecCV(CV_VOLATILE), $1 }
 |   RESTRICT                            { SpecCV(CV_RESTRICT), $1 }
+|   ATOMIC                              { SpecCV(CV_ATOMIC), $1 }
 ;
 
 /*** GCC attributes ***/

--- a/src/frontc/cprint.ml
+++ b/src/frontc/cprint.ml
@@ -156,7 +156,8 @@ let rec print_specifiers (specs: spec_elem list) =
         printu (match cv with
         | CV_CONST -> "const"
         | CV_VOLATILE -> "volatile"
-        | CV_RESTRICT -> "restrict")
+        | CV_RESTRICT -> "restrict"
+        | CV_ATOMIC -> "_Atomic")
     | SpecAttr al -> print_attribute al; space ()
     | SpecType bt -> print_type_spec bt
     | SpecPattern name -> printl ["@specifier";"(";name;")"]
@@ -203,6 +204,7 @@ and print_type_spec = function
       (print_enum_items enum_items)
   | TtypeofE e -> printl ["__typeof__";"("]; print_expression e; print ") "
   | TtypeofT (s,d) -> printl ["__typeof__";"("]; print_onlytype (s, d); print ") "
+  | Tautotype -> print "__auto_type "
 
 
 (* print "struct foo", but with specified keyword and a list of

--- a/test/Makefile
+++ b/test/Makefile
@@ -363,6 +363,14 @@ mergestruct: $(TESTDIR)/small2/mergestruct1.c $(TESTDIR)/small2/mergestruct2.c
 	  $(CILLY) mergestruct1.c mergestruct2.c -o mergestruct.exe
 	$(TESTDIR)/small2/mergestruct.exe
 
+# sc: this tests for a merger bug in global variables initializations
+mergeinit: $(TESTDIR)/small2/mergeinit1.h $(TESTDIR)/small2/mergeinit1.c \
+           $(TESTDIR)/small2/mergeinit2.h $(TESTDIR)/small2/mergeinit2_1_reftable.c $(TESTDIR)/small2/mergeinit2_2_definition.c \
+           $(TESTDIR)/small2/mergeinit3.h $(TESTDIR)/small2/mergeinit3.c \
+           $(TESTDIR)/small2/mergeinit4.c
+	cd $(TESTDIR)/small2; \
+	  $(CILLY) --merge --strictcheck --keepunused mergeinit1.c mergeinit2_1_reftable.c mergeinit2_2_definition.c mergeinit3.c mergeinit4.c
+
 # sm: yet another merger test (I know there's a target somewhere)
 mergeinline: $(TESTDIR)/small2/mergeinline1.c $(TESTDIR)/small2/mergeinline2.c
 	cd $(TESTDIR)/small2; \

--- a/test/small1/asm_emptyclobberallowed.c
+++ b/test/small1/asm_emptyclobberallowed.c
@@ -1,0 +1,8 @@
+
+int main(){
+  asm ("xor %%eax, %%eax"
+       : /* No outputs. */
+       : /* No inputs */
+       : );
+  return(0);
+}

--- a/test/small2/mergeinit1.c
+++ b/test/small2/mergeinit1.c
@@ -1,0 +1,7 @@
+
+int f1(void)
+{
+	return(1);
+}
+
+

--- a/test/small2/mergeinit1.h
+++ b/test/small2/mergeinit1.h
@@ -1,0 +1,2 @@
+
+extern int f1(void);

--- a/test/small2/mergeinit2.h
+++ b/test/small2/mergeinit2.h
@@ -1,0 +1,2 @@
+
+extern int (*table[2])();

--- a/test/small2/mergeinit2_1_reftable.c
+++ b/test/small2/mergeinit2_1_reftable.c
@@ -1,0 +1,2 @@
+#include "mergeinit2.h"
+

--- a/test/small2/mergeinit2_2_definition.c
+++ b/test/small2/mergeinit2_2_definition.c
@@ -1,0 +1,10 @@
+#include "mergeinit1.h"
+#include "mergeinit2.h"
+#include "mergeinit3.h"
+
+
+int (*table[2])(void) =
+{
+      &f1,
+      &f3
+};

--- a/test/small2/mergeinit3.c
+++ b/test/small2/mergeinit3.c
@@ -1,0 +1,7 @@
+
+int f3(void)
+{
+	return(3);
+}
+
+

--- a/test/small2/mergeinit3.h
+++ b/test/small2/mergeinit3.h
@@ -1,0 +1,2 @@
+
+extern int f3(void);

--- a/test/small2/mergeinit4.c
+++ b/test/small2/mergeinit4.c
@@ -1,0 +1,5 @@
+#include "mergeinit2.h"
+
+int main(){
+	return(table[0]());
+}

--- a/test/testcil.pl
+++ b/test/testcil.pl
@@ -198,6 +198,7 @@ addTest("testrun/asm1 _GNUCC=1");
 addTest("test/asm2 _GNUCC=1");
 addTest("test/asm3 _GNUCC=1");
 addTest("test/asm4 _GNUCC=1");
+addTest("test/asm_emptyclobberallowed _GNUCC=1");
 addTest("testobj/asm5 _GNUCC=1");
 
 addTest("testrun/offsetof");

--- a/test/testcil.pl
+++ b/test/testcil.pl
@@ -654,6 +654,9 @@ addBadComment("testrun/constfold", "Bug. Wrong constant folding.  #2276515 on so
 # tests of things implemented for EDG compatibility
 addTest("mergestruct");
 
+# Test for a merge bug in global variables initializations
+addTest("mergeinit");
+
 # a few things that should fail
 addTest("test-bad/trivial-tb");
 addTest("runall/runall_misc");


### PR DESCRIPTION
For the moment _Atomic is only supported as a qualifier and not a
specifier (ie `_Atomic int` and not `_Atomic(int)`)

__auto_type is a GCC extension working like the auto keyword in C++11

This PR also includes some fixes made upstream in the CIL repository, and patch the .merlin file.