### PR TITLE
Changes to allow building with OCaml 4.08.1, as String is now immutable

### DIFF
--- a/src/cil.ml
+++ b/src/cil.ml
@@ -5271,19 +5271,19 @@ let loadBinaryFile (filename : string) : file =
 (* Take the name of a file and make a valid symbol name out of it. There are 
  * a few characters that are not valid in symbols *)
 let makeValidSymbolName (s: string) = 
-  let s = String.copy s in (* So that we can update in place *)
-  let l = String.length s in
+  let s_bytes = Bytes.of_string s in (* So that we can update in place *)
+  let l = Bytes.length s_bytes in
   for i = 0 to l - 1 do
-    let c = String.get s i in
+    let c = Bytes.get s_bytes i in
     let isinvalid = 
       match c with
         '-' | '.' -> true
       | _ -> false
     in
     if isinvalid then 
-      String.set s i '_';
+      Bytes.set s_bytes i '_';
   done;
-  s
+  Bytes.to_string s_bytes
 
 let rec addOffset (toadd: offset) (off: offset) : offset =
   match off with

--- a/src/formatlex.mll
+++ b/src/formatlex.mll
@@ -156,11 +156,11 @@ let scan_oct_escape str =
  * We convert L"Hi" to "H\000i\000" *)
 let wbtowc wstr =
   let len = String.length wstr in 
-  let dest = String.make (len * 2) '\000' in 
-  for i = 0 to len-1 do 
+  let dest = Bytes.make (len * 2) '\000' in 
+  for i = 0 to len-1 do
     dest.[i*2] <- wstr.[i] ;
   done ;
-  dest
+  Bytes.to_string dest
 
 (* This function converst the "Hi" in L"Hi" to { L'H', L'i', L'\0' } *)
 let wstr_to_warray wstr =

--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -2087,7 +2087,7 @@ let rec setOneInit (this: preInit)
       let pMaxIdx, pArray = 
         match this  with 
           NoInitPre  -> (* No initializer so far here *)
-            ref idx, ref (Array.create (max 32 (idx + 1)) NoInitPre)
+            ref idx, ref (Array.make (max 32 (idx + 1)) NoInitPre)
               
         | CompoundPre (pMaxIdx, pArray) -> 
             if !pMaxIdx < idx then begin 

--- a/src/ocamlutil/bitmap.ml
+++ b/src/ocamlutil/bitmap.ml
@@ -10,7 +10,7 @@ type t = { mutable nrWords  : int;
 let enlarge b newWords = 
   let newbitmap = 
     if newWords > b.nrWords then
-      let a = Array.create newWords Int32.zero in
+      let a = Array.make newWords Int32.zero in
       Array.blit b.bitmap 0 a 0 b.nrWords;
       a
     else

--- a/src/ocamlutil/errormsg.ml
+++ b/src/ocamlutil/errormsg.ml
@@ -209,18 +209,18 @@ let rem_quotes str = String.sub str 1 ((String.length str) - 2)
 let cleanFileName str = 
   let str1 = 
     if str <> "" && String.get str 0 = '"' (* '"' ( *) 
-    then rem_quotes str else str in
-  let l = String.length str1 in
+    then Bytes.of_string (rem_quotes str) else Bytes.of_string(str) in
+  let l = Bytes.length str1 in
   let rec loop (copyto: int) (i: int) = 
     if i >= l then 
-      String.sub str1 0 copyto
+      Bytes.to_string (Bytes.sub str1 0 copyto)
      else 
-       let c = String.get str1 i in
+       let c = Bytes.get str1 i in
        if c <> '\\' then begin
-          String.set str1 copyto c; loop (copyto + 1) (i + 1)
+          Bytes.set str1 copyto c; loop (copyto + 1) (i + 1)
        end else begin
-          String.set str1 copyto '/';
-          if i < l - 2 && String.get str1 (i + 1) = '\\' then
+          Bytes.set str1 copyto '/';
+          if i < l - 2 && Bytes.get str1 (i + 1) = '\\' then
               loop (copyto + 1) (i + 2)
           else 
               loop (copyto + 1) (i + 1)

--- a/src/ocamlutil/pretty.ml
+++ b/src/ocamlutil/pretty.ml
@@ -725,31 +725,31 @@ let gprintf (finish : doc -> 'b)
               invalid_arg ("dprintf: unimplemented format " 
 			   ^ (String.sub format i (j-i+1)));
 	    let j' = succ j in (* eat the d,i,x etc. *)
-	    let format_spec = "% " in
-	    String.set format_spec 1 (fget j'); (* format_spec = "%x", etc. *)
+	    let format_spec = (Bytes.of_string "% ") in
+	    Bytes.set format_spec 1 (fget j'); (* format_spec = "%x", etc. *)
             Obj.magic(fun n ->
               collect (dctext1 acc
-                         (Int64.format format_spec n))
+                         (Int64.format (Bytes.to_string format_spec) n))
                 (succ j'))
 	| 'l' ->
 	    if j != i + 1 then invalid_arg ("dprintf: unimplemented format " 
 					    ^ (String.sub format i (j-i+1)));
 	    let j' = succ j in (* eat the d,i,x etc. *)
-	    let format_spec = "% " in
-	    String.set format_spec 1 (fget j'); (* format_spec = "%x", etc. *)
+	    let format_spec = (Bytes.of_string "% ") in
+	    Bytes.set format_spec 1 (fget j'); (* format_spec = "%x", etc. *)
             Obj.magic(fun n ->
               collect (dctext1 acc
-                         (Int32.format format_spec n))
+                         (Int32.format (Bytes.to_string format_spec) n))
                 (succ j'))
 	| 'n' ->
 	    if j != i + 1 then invalid_arg ("dprintf: unimplemented format " 
 					    ^ (String.sub format i (j-i+1)));
 	    let j' = succ j in (* eat the d,i,x etc. *)
-	    let format_spec = "% " in
-	    String.set format_spec 1 (fget j'); (* format_spec = "%x", etc. *)
+	    let format_spec = (Bytes.of_string "% ") in
+	    Bytes.set format_spec 1 (fget j'); (* format_spec = "%x", etc. *)
             Obj.magic(fun n ->
               collect (dctext1 acc
-                         (Nativeint.format format_spec n))
+                         (Nativeint.format (Bytes.to_string format_spec) n))
                 (succ j'))
         | 'f' | 'e' | 'E' | 'g' | 'G' ->
             Obj.magic(fun f ->


### PR DESCRIPTION
Minimal set of changes to allow building with OCaml 4.08.1, to cater for the fact that String is immutable. 
Casting to Bytes and then back again provides a workaround.

There are many more deprecated functions and warnings found in 4.08.1, this is only a patch for the errors which prevented building.