### PR TITLE
Add a type specifier for `unsigned __int128`

### DIFF
--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -2600,6 +2600,7 @@ let rec doSpecList (suggestedAnonName: string) (* This string will be part of
     | [A.Tint128] -> TInt(IInt128, [])
     | [A.Tuint128] -> TInt(IUInt128, [])
     | [A.Tsigned; A.Tint128] -> TInt(IInt128, [])
+    | [A.Tunsigned; A.Tint128] -> TInt(IUInt128, [])
     | [A.Tunsigned; A.Tint64] -> TInt(IUInt128, [])
 
     | [A.Tfloat] -> TFloat(FFloat, [])


### PR DESCRIPTION
The following MWE breaks...:

 ```c
 typedef unsigned __int128 __u128;
 int main() {
 __u128 somevar = 2;
 return 0;
 }
 ```

It compiles correctly with clang and gcc but raises the following error when given to cilly…

 ```
 (eboss)tom@er-colo-inf01:/usr/local/src/liballocs$ cilly test.c
 perl: warning: Setting locale failed.
 perl: warning: Please check that your locale settings:
         LANGUAGE = (unset),
         LC_ALL = (unset),
         LANG = "en_GB.UTF-8"
     are supported and installed on your system.
 perl: warning: Falling back to the standard locale ("C").
 test.c:1: Error: Invalid combination of type specifiers
 Error on A.TYPEDEF (Errormsg.Error)
 test.c:3: Error: Cannot find type __u128 (kind:type)
 Error in doStatement (Errormsg.Error)
 Error: Cabs2cil had some errors
 Fatal error: exception Errormsg.Error
 ```

 …because `unsigned __int128` isn’t a valid combination of type specifiers in CIL, causing the typedef not to be parsed (and, later, the lookup of the new type to fail!)

This fixes it by adding the required type specifier.