### PR TITLE
Function attribute fixes

### DIFF
--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -1572,9 +1572,20 @@ type combineWhat =
  * that are known to be equal *)
 let isomorphicStructs : (string * string, bool) H.t = H.create 15
 
-let rec combineTypes (what: combineWhat) (oldt: typ) (t: typ) : typ = 
+let rec combineTypes (what: combineWhat) (oldt: typ) (t: typ) : typ =
+  let combineAttributes olda a =
+          if what = CombineFunarg || what = CombineFunret then dropAttribute "const" (cabsAddAttributes olda a)
+     else cabsAddAttributes olda a
+  in
+  let combineAddAttributes olda a =
+     if what = CombineFunarg || what  = CombineFunret then dropAttribute "const" (addAttributes olda a)
+     else addAttributes olda a
+  in
+  let combineTypeAttributes olda a =
+     cabsTypeAddAttributes olda a
+  in
   match oldt, t with
-  | TVoid olda, TVoid a -> TVoid (cabsAddAttributes olda a)
+  | TVoid olda, TVoid a -> TVoid (combineAttributes olda a)
   | TInt (oldik, olda), TInt (ik, a) -> 
       let combineIK oldk k = 
         if oldk = k then oldk else
@@ -1586,7 +1597,7 @@ let rec combineTypes (what: combineWhat) (oldt: typ) (t: typ) : typ =
         else
           raise (Failure "different integer types")
       in
-      TInt (combineIK oldik ik, cabsAddAttributes olda a)
+      TInt (combineIK oldik ik, combineAttributes olda a)
   | TFloat (oldfk, olda), TFloat (fk, a) -> 
       let combineFK oldk k = 
         if oldk = k then oldk else
@@ -1598,21 +1609,21 @@ let rec combineTypes (what: combineWhat) (oldt: typ) (t: typ) : typ =
         else
           raise (Failure "different floating point types")
       in
-      TFloat (combineFK oldfk fk, cabsAddAttributes olda a)
+      TFloat (combineFK oldfk fk, combineAttributes olda a)
   | TEnum (_, olda), TEnum (ei, a) -> 
-      TEnum (ei, cabsAddAttributes olda a)
+      TEnum (ei, combineAttributes olda a)
         
         (* Strange one. But seems to be handled by GCC *)
   | TEnum (oldei, olda) , TInt(IInt, a) -> TEnum(oldei, 
-                                                 cabsAddAttributes olda a)
+                                                 combineAttributes olda a)
         (* Strange one. But seems to be handled by GCC *)
-  | TInt(IInt, olda), TEnum (ei, a) -> TEnum(ei, cabsAddAttributes olda a)
+  | TInt(IInt, olda), TEnum (ei, a) -> TEnum(ei, combineAttributes olda a)
         
         
   | TComp (oldci, olda) , TComp (ci, a) -> 
       if oldci.cstruct <> ci.cstruct then 
         raise (Failure "different struct/union types");
-      let comb_a = cabsAddAttributes olda a in
+      let comb_a = combineAttributes olda a in
       if oldci.cname = ci.cname then 
         TComp (oldci, comb_a)
       else 
@@ -1697,16 +1708,16 @@ let rec combineTypes (what: combineWhat) (oldt: typ) (t: typ) : typ =
               raise (Failure "different array lengths")
            
       in
-      TArray (newbt, newsz, cabsAddAttributes olda a)
+      TArray (newbt, newsz, combineAttributes olda a)
         
   | TPtr (oldbt, olda), TPtr (bt, a) -> 
-      TPtr (combineTypes CombineOther oldbt bt, cabsAddAttributes olda a)
+      TPtr (combineTypes CombineOther oldbt bt, combineAttributes olda a)
         
   | TFun (_, _, _, [Attr("missingproto",_)]), TFun _ -> t
         
   | TFun (oldrt, oldargs, oldva, olda), TFun (rt, args, va, a) ->
       if oldva != va then 
-        raise (Failure "diferent vararg specifiers");
+        raise (Failure "different vararg specifiers");
       let defrt = combineTypes 
           (if what = CombineFundef then CombineFunret else CombineOther) 
           oldrt rt in
@@ -1743,7 +1754,7 @@ let rec combineTypes (what: combineWhat) (oldt: typ) (t: typ) : typ =
                        CombineFunarg else CombineOther) 
                      ot' at
                  in
-                 let a = addAttributes oa aa in
+                 let a = combineAddAttributes oa aa in
                  (n, t, a))
                oldargslist argslist),
 	  (let oldrt' = !typeForCombinedArg map oldrt in
@@ -1753,23 +1764,23 @@ let rec combineTypes (what: combineWhat) (oldt: typ) (t: typ) : typ =
 	  !attrsForCombinedArg map olda
         end
       in
-      TFun (newrt, newargs, oldva, cabsAddAttributes olda' a)
+      TFun (newrt, newargs, oldva, combineAttributes olda' a)
         
   | TNamed (oldt, olda), TNamed (t, a) when oldt.tname = t.tname ->
-      TNamed (oldt, cabsAddAttributes olda a)
+      TNamed (oldt, combineAttributes olda a)
         
   | TBuiltin_va_list olda, TBuiltin_va_list a -> 
-      TBuiltin_va_list (cabsAddAttributes olda a)
+      TBuiltin_va_list (combineAttributes olda a)
 
         (* Unroll first the new type *)
   | _, TNamed (t, a) -> 
       let res = combineTypes what oldt t.ttype in
-      cabsTypeAddAttributes a res
+      combineTypeAttributes a res
         
         (* And unroll the old type as well if necessary *)
   | TNamed (oldt, a), _ -> 
       let res = combineTypes what oldt.ttype t in
-      cabsTypeAddAttributes a res
+      combineTypeAttributes a res
         
   | _ -> raise (Failure "different type constructors")
 
@@ -1829,9 +1840,8 @@ let makeGlobalVarinfo (isadef: bool) (vi: varinfo) : varinfo * bool =
      * or a new def with an old GVarDecl.
      * First, snapshot the incoming declaration -- whether or not it's
      * also a definition -- as a GVarDecl. FIXME: why not just as whatever it really is?  *)
-    oldvi.vvardecls <- (let glob = if isadef then (GVarDecl(oldvi, vi.vdecl)) else (GVarDecl(oldvi, vi.vdecl))
-        in let decl = { dstorage = vi.vstorage; dinline = vi.vinline; dattr = vi.vattr; }
-        in (glob, decl) :: oldvi.vvardecls);
+    oldvi.vvardecls <- (let decl = { dstorage = vi.vstorage; dinline = vi.vinline; dattr = vi.vattr; }
+        in (GVarDecl(oldvi, vi.vdecl), decl) :: oldvi.vvardecls);
     oldvi.vtype <- (try combineTypes
             (if isadef then CombineFundef else CombineOther) oldvi.vtype vi.vtype
           with Failure reason ->
@@ -4309,8 +4319,16 @@ and doExp (asconst: bool)   (* This expression is used as a constant *)
                                          * takes INTs as arguments  *)
             A.VARIABLE n -> begin
               try
+                (* NB: the type looked up here may be slightly inconsistent
+                 * with the type used in the function's implementation. This is
+                 * because `const` and `volatile` attributes can exist in
+                 * prototypes but be missing in a function's implementation
+                 * (see C++03 13.1-3). That means that our output can be
+                 * inconsistent with the original source: we might introduce
+                 * casting to `const` or `volatile` that a function's
+                 * implementation doesn't expect. *)
                 let vi, _ = lookupVar n in
-                (empty, Lval(var vi), vi.vtype) (* Found. Do not use 
+                (empty, Lval(var vi), vi.vtype) (* Found. Do not use
                                                  * finishExp. Simulate what = 
                                                  * AExp None  *)
               with Not_found -> begin

--- a/src/frontc/cparser.mly
+++ b/src/frontc/cparser.mly
@@ -84,6 +84,18 @@ let smooth_expression lst =
 
 
 let currentFunctionName = ref "<outside any function>"
+
+let functionSpecificAttributes =
+        [
+         (SpecAttr ("__attribute__", [VARIABLE "__pure__"]))
+        ]
+let separateFunctionAttrsFromSpecifiers specifiers =
+        let isFunctionSpecific attr = List.mem attr functionSpecificAttributes in
+        let specAttrToAttribute (SpecAttr attr) = attr in
+        let specsFunctionSpecific = List.filter isFunctionSpecific specifiers in
+        let attrsFunctionSpecific = List.map specAttrToAttribute specsFunctionSpecific in
+        let specsNonFunctionSpecific = List.filter (Fun.negate isFunctionSpecific) specifiers in
+        (attrsFunctionSpecific, specsNonFunctionSpecific)
     
 let announceFunctionName ((n, decl, _, _):name) =
   !Lexerhack.add_identifier n;
@@ -1257,8 +1269,14 @@ function_def:  /* (* ISO 6.9.1 *) */
 
 function_def_start:  /* (* ISO 6.9.1 *) */
   decl_spec_list declarator   
-                            { announceFunctionName $2;
-                              (snd $1, fst $1, $2)
+                            {
+                              announceFunctionName $2;
+                              let (functionSpecificAttrs, nonFuncSpecificAttrs) = separateFunctionAttrsFromSpecifiers (fst $1) in
+                              if List.length functionSpecificAttrs = 0 then
+                                  (snd $1, fst $1, $2)
+                              else
+                                  let (n_name, n_type, n_attrlist, n_cabsloc) = $2 in
+                                  (snd $1, nonFuncSpecificAttrs, (n_name, PARENTYPE(functionSpecificAttrs, n_type, []), n_attrlist, n_cabsloc))
                             } 
 
 /* (* Old-style function prototype *) */


### PR DESCRIPTION
Fixes two bugs:

1. Drop `const` from arguments when merging function signatures, to avoid prototypes enforcing `const` on the arguments in a function implementation (which can differ from a prototype in its use of `const`)
2. Correctly parse attributes that uniquely apply to functions, like `__attribute__((__pure__))`, so that they're not parsed as an attribute of the function's return type

At time of writing the second part might need a little more testing — currently having some trouble with cilly / allocscc — but the `cabsprint` utility indicates it's working correctly…