### PR TITLE
Add `pure` attribute to list of function attrs

### DIFF
--- a/src/cil.ml
+++ b/src/cil.ml
@@ -1479,7 +1479,7 @@ let attributeHash: (string, attributeClass) H.t =
   List.iter (fun a -> H.add table a (AttrFunType false))
     [ "format"; "regparm"; "longcall"; 
       "noinline"; "always_inline"; "gnu_inline"; "leaf"; "cold"; "alloc_size";
-      "artificial"; "warn_unused_result"; "nonnull";
+      "artificial"; "warn_unused_result"; "nonnull"; "pure";
     ];
 
   List.iter (fun a -> H.add table a (AttrFunType true))


### PR DESCRIPTION
Seems to me that this might be sufficient to correctly parse `__attribute__((__pure__)) as a function attr and not as an attr of the return type.