### PR TITLE
Support for attribute spec sequences (`[[]]` syntax)

### DIFF
--- a/src/frontc/clexer.mll
+++ b/src/frontc/clexer.mll
@@ -597,7 +597,8 @@ rule initial =
 	
 |		'{'		       {dbgToken (LBRACE (currentLoc ()))}
 |		'}'		       {dbgToken (RBRACE (currentLoc ()))}
-|		'['				{LBRACKET}
+|		"[["				{dbgToken (DOUBLE_LBRACKET (currentLoc ()))}
+|		'['				{dbgToken (LBRACKET (currentLoc ()))}
 |		']'				{RBRACKET}
 |		'('		       {dbgToken (LPAREN (currentLoc ())) }
 |		')'				{RPAREN}

--- a/src/frontc/cparser.mly
+++ b/src/frontc/cparser.mly
@@ -294,7 +294,8 @@ let transformOffsetOf (speclist, dtype) member =
 %token RPAREN 
 %token<Cabs.cabsloc> LPAREN RBRACE
 %token<Cabs.cabsloc> LBRACE
-%token LBRACKET RBRACKET
+%token<Cabs.cabsloc> DOUBLE_LBRACKET LBRACKET
+%token RBRACKET
 %token COLON
 %token<Cabs.cabsloc> SEMICOLON
 %token COMMA ELLIPSIS QUEST
@@ -1116,6 +1117,9 @@ direct_decl: /* (* ISO 6.7.5 *) */
 |   LPAREN attributes declarator RPAREN
                                    { let (n,decl,al,loc) = $3 in
                                      (n, PARENTYPE($2,decl,al)) }
+|   direct_decl LBRACKET LBRACKET attr_list RBRACKET RBRACKET 
+                                   { let (n, decl) = $1 in
+                                     (n, ARRAY(decl, [("__attribute__", $4)], NOTHING)) }
 
 |   direct_decl LBRACKET attributes comma_expression_opt RBRACKET
                                    { let (n, decl) = $1 in
@@ -1353,6 +1357,8 @@ attribute_nocv:
 |   ATTRIBUTE_USED                      { ("__attribute__", 
                                              [ VARIABLE "used" ]), $1 }
 *)*/
+|   DOUBLE_LBRACKET attr_list_ne RBRACKET RBRACKET
+                                        {("__attribute__", $2), $1}
 |   DECLSPEC paren_attr_list_ne         { ("__declspec", $2), $1 }
 |   MSATTR                              { (fst $1, []), snd $1 }
                                         /* ISO 6.7.3 */
@@ -1380,6 +1386,8 @@ just_attribute:
     ATTRIBUTE LPAREN paren_attr_list RPAREN
                                         { ("__attribute__", $3) }
 |   DECLSPEC paren_attr_list_ne         { ("__declspec", $2) }
+|   DOUBLE_LBRACKET attr_list_ne RBRACKET RBRACKET
+                                        {("__attribute__", $2)}
 ;
 
 /* this can't be empty, b/c I folded that possibility into the calling


### PR DESCRIPTION
Adds _basic_ support for attribute specifier sequences. They can have extra syntax (e.g. namespaces indicating the compiler attributes are available in) but right now we don't bother with that and treat them as attributes within double square brackets, which seems to suffice for e.g. GNUTLS.