### PR TITLE
[WIP] Fallthrough statement support

### DIFF
--- a/src/cfg.ml
+++ b/src/cfg.ml
@@ -43,6 +43,7 @@
 
 open Pretty
 open Cil
+open Option
 module E=Errormsg
 
 (* entry points: cfgFun, printCfgChannel, printCfgFilename *)
@@ -197,6 +198,7 @@ and cfgStmt (s: stmt) (next:stmt option) (break:stmt option) (cont:stmt option)
   | Goto (p,_) -> addSucc !p
   | ComputedGoto (e,_) -> List.iter addSucc rlabels
   | Break _ -> addOptionSucc break
+  | Fallthrough _ -> addOptionSucc (some dummyStmt)
   | Continue _ -> addOptionSucc cont
   | If (_, blk1, blk2, _) ->
       (* The succs of If is [true branch;false branch] *)
@@ -249,7 +251,7 @@ and fasStmt (todo) (s : stmt) =
       | If (_, tb, fb, _) -> (fasBlock todo tb; fasBlock todo fb)
       | Switch (_, b, _, _) -> fasBlock todo b
       | Loop (b, _, _, _) -> fasBlock todo b
-      | (Return _ | Break _ | Continue _ | Goto _ | ComputedGoto _ | Instr _) -> ()
+      | (Return _ | Fallthrough _ | Break _ | Continue _ | Goto _ | ComputedGoto _ | Instr _) -> ()
       | TryExcept _ | TryFinally _ -> E.s (E.unimp "try/except/finally")
   end
 ;;
@@ -267,6 +269,7 @@ let d_cfgnodelabel () (s : stmt) =
       | If (e, _, _, _)  -> "if" (*sprint ~width:999 (dprintf "if %a" d_exp e)*)
       | Loop _ -> "loop"
       | Break _ -> "break"
+      | Fallthrough _ -> "fallthrough"
       | Continue _ -> "continue"
       | Goto _ | ComputedGoto _ -> "goto"
       | Instr _ -> "instr"

--- a/src/cil.ml
+++ b/src/cil.ml
@@ -823,6 +823,9 @@ and stmtkind =
 
   | Break of location                   (** A break to the end of the nearest 
                                              enclosing Loop or Switch *)
+  | Fallthrough of location             (** A fallthrough statement indicating
+                                            the compiler that fallthrough behaviour
+                                            is expected. *)
   | Continue of location                (** A continue to the start of the 
                                             nearest enclosing [Loop] *)
   | If of exp * block * block * location (** A conditional. 
@@ -1172,6 +1175,7 @@ let rec get_stmtLoc (statement : stmtkind) =
     | Goto(_, loc) -> loc
     | ComputedGoto(_, loc) -> loc
     | Break(loc) -> loc
+    | Fallthrough(loc) -> loc
     | Continue(loc) -> loc
     | If(_, _, _, loc) -> loc
     | Switch (_, _, _, loc) -> loc
@@ -4070,6 +4074,10 @@ class defaultCilPrinterClass : cilPrinter = object (self)
         self#pLineDirective l
           ++ text "break;"
 
+    | Fallthrough l ->
+        self#pLineDirective l
+          ++ text "[[fallthrough]];"
+
     | Continue l -> 
         self#pLineDirective l
           ++ text "continue;"
@@ -5646,7 +5654,7 @@ and childrenStmt (toPrepend: instr list ref) : cilVisitor -> stmt -> stmt =
   (* Just change the statement kind *)
   let skind' = 
     match s.skind with
-      Break _ | Continue _ | Goto _ | Return (None, _) -> s.skind
+      Break _ | Continue _ | Goto _ | Return (None, _) | Fallthrough _ -> s.skind
     | ComputedGoto (e, l) ->
          let e' = fExp e in
          if e' != e then ComputedGoto (e', l) else s.skind
@@ -6197,7 +6205,7 @@ let rec peepHole1 (* Process one instruction and possibly replace it *)
           peepHole1 doone b.bstmts; 
           peepHole1 doone h.bstmts;
           s.skind <- TryExcept(b, (doInstrList il, e), h, l);
-      | Return _ | Goto _ | ComputedGoto _ | Break _ | Continue _ -> ())
+      | Return _ | Goto _ | ComputedGoto _ | Break _ | Continue _ | Fallthrough _ -> ())
     ss
 
 let rec peepHole2  (* Process two instructions and possibly replace them both *)
@@ -6231,7 +6239,7 @@ let rec peepHole2  (* Process two instructions and possibly replace them both *)
           peepHole2 dotwo h.bstmts;
           s.skind <- TryExcept (b, (doInstrList il, e), h, l)
 
-      | Return _ | Goto _ | ComputedGoto _ | Break _ | Continue _ -> ())
+      | Return _ | Goto _ | ComputedGoto _ | Break _ | Continue _ | Fallthrough _ -> ())
     ss
 
 
@@ -6847,6 +6855,7 @@ and succpred_stmt s fallthrough rlabels =
   | Goto(dest,l) -> link s !dest
   | ComputedGoto(e,l) ->  List.iter (link s) rlabels
   | Break _  
+  | Fallthrough _  
   | Continue _ 
   | Switch _ ->
     failwith "computeCFGInfo: cannot be called on functions with break, continue or switch statements. Use prepareCFG first to remove them."
@@ -6937,6 +6946,12 @@ let rec xform_switch_stmt s break_dest cont_dest = begin
   ) s.labels ; 
   match s.skind with
   | Instr _ | Return _ | Goto _ | ComputedGoto _ -> ()
+  | Fallthrough _ -> begin try
+                           s.skind <- Instr [(Asm([], [""], [], [], [], lu))] (* I believe this is OK... *)
+                   with e ->
+                           ignore (error "prepareCFG: fallthrough: %a@!" d_stmt s);
+                           raise e
+                   end
   | Break(l) -> begin try 
                   s.skind <- Goto(break_dest (),l)
                 with e ->

--- a/src/cil.mli
+++ b/src/cil.mli
@@ -997,6 +997,9 @@ and stmtkind =
   | Break of location                   
    (** A break to the end of the nearest enclosing Loop or Switch *)
 
+  | Fallthrough of location
+  (** Fallthrough statement indicates to the compiler that fallthrough really is expected *)
+
   | Continue of location                
    (** A continue to the start of the nearest enclosing [Loop] *)
   | If of exp * block * block * location 

--- a/src/formatlex.mll
+++ b/src/formatlex.mll
@@ -82,6 +82,7 @@ let init ~(prog: string) : Lexing.lexbuf =
       ("typedef", TYPEDEF);
       ("union", UNION);
       ("break", BREAK);
+      ("[[fallthrough]]", FALLTHROUGH);
       ("continue", CONTINUE);
       ("goto", GOTO); 
       ("return", RETURN);

--- a/src/formatparse.mly
+++ b/src/formatparse.mly
@@ -263,7 +263,7 @@ type maybeInit =
 %token RPAREN LPAREN RBRACE LBRACE LBRACKET RBRACKET
 %token COLON SEMICOLON COMMA ELLIPSIS QUEST
 
-%token BREAK CONTINUE GOTO RETURN
+%token BREAK CONTINUE GOTO RETURN FALLTHROUGH
 %token SWITCH CASE DEFAULT
 %token WHILE DO FOR
 %token IF THEN ELSE
@@ -1331,6 +1331,10 @@ stmt:
 |   RETURN exp_opt SEMICOLON  
                   { (fun mkTemp loc args -> 
                          mkStmt (Return((fst $2) args, loc))) 
+                  }
+|   FALLTHROUGH SEMICOLON
+                  { (fun mkTemp loc args ->
+                         mkStmt (Fallthrough loc))
                   }
 |   BREAK SEMICOLON  
                   { (fun mkTemp loc args -> 

--- a/src/frontc/cabs.ml
+++ b/src/frontc/cabs.ml
@@ -221,6 +221,7 @@ and statement =
  | DOWHILE of expression * statement * cabsloc
  | FOR of for_clause * expression * expression * statement * cabsloc
  | BREAK of cabsloc
+ | FALLTHROUGH of cabsloc
  | CONTINUE of cabsloc
  | RETURN of expression * cabsloc
  | SWITCH of expression * statement * cabsloc

--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -1023,6 +1023,12 @@ module BlockChunk =
         postins = [];
         cases = body.cases;
       } 
+
+    let fallthroughChunk (l: location) : chunk = 
+      { stmts = [ mkStmt (Fallthrough l) ];
+        postins = [];
+        cases = [];
+      }
       
     let breakChunk (l: location) : chunk = 
       { stmts = [ mkStmt (Break l) ];
@@ -6336,6 +6342,7 @@ and doDecl (isglobal: bool) : A.definition -> chunk = function
                                       acc && instrFallsThrough elt) true il
               | Return _ | Break _ | Continue _ -> false
               | Goto _ | ComputedGoto _ -> false
+              | Fallthrough _ -> true (* I think this is correct? Only a valid statement in specific cases! *)
               | If (_, b1, b2, _) -> 
                   blockFallsThrough b1 || blockFallsThrough b2
               | Switch (e, b, targets, _) -> 
@@ -6398,6 +6405,7 @@ and doDecl (isglobal: bool) : A.definition -> chunk = function
             and stmtCanBreak (s: stmt) : bool = 
               match s.skind with
                 Instr _ | Return _ | Continue _ | Goto _ | ComputedGoto _ -> false
+              | Fallthrough _ -> false
               | Break _ -> true
               | If (_, b1, b2, _) -> 
                   blockCanBreak b1 || blockCanBreak b2
@@ -6704,6 +6712,11 @@ and doStatement (s : A.statement) : chunk =
         let loc' = convLoc loc in
         currentLoc := loc';
         breakChunk loc'
+
+    | A.FALLTHROUGH loc ->
+        let loc' = convLoc loc in
+        currentLoc := loc';
+        fallthroughChunk loc'
 
     | A.CONTINUE loc -> 
         let loc' = convLoc loc in

--- a/src/frontc/cabshelper.ml
+++ b/src/frontc/cabshelper.ml
@@ -72,6 +72,7 @@ begin
   | DOWHILE(_,_,loc) -> loc
   | FOR(_,_,_,_,loc) -> loc
   | BREAK(loc) -> loc
+  | FALLTHROUGH(loc) -> loc
   | CONTINUE(loc) -> loc
   | RETURN(_,loc) -> loc
   | SWITCH(_,_,loc) -> loc

--- a/src/frontc/cabsvisit.ml
+++ b/src/frontc/cabsvisit.ml
@@ -404,7 +404,7 @@ and childrenStatement vis s =
       let _ = vis#vExitScope () in
       if fc1' != fc1 || e2' != e2 || e3' != e3 || s4' != s4 
       then FOR (fc1', e2', e3', s4', l) else s
-  | BREAK _ | CONTINUE _ | GOTO _ -> s
+  | BREAK _ | CONTINUE _ | GOTO _ | FALLTHROUGH _-> s
   | RETURN (e, l) ->
       let e' = ve e in
       if e' != e then RETURN (e', l) else s

--- a/src/frontc/clexer.mll
+++ b/src/frontc/clexer.mll
@@ -597,7 +597,8 @@ rule initial =
 	
 |		'{'		       {dbgToken (LBRACE (currentLoc ()))}
 |		'}'		       {dbgToken (RBRACE (currentLoc ()))}
-|		'['				{LBRACKET}
+|		"[["				{dbgToken (DOUBLE_LBRACKET (currentLoc ()))}
+|		'['				{dbgToken (LBRACKET (currentLoc ()))}
 |		']'				{RBRACKET}
 |		'('		       {dbgToken (LPAREN (currentLoc ())) }
 |		')'				{RPAREN}

--- a/src/frontc/clexer.mll
+++ b/src/frontc/clexer.mll
@@ -144,6 +144,9 @@ let init_lexicon _ =
       ("typedef", fun loc -> TYPEDEF loc);
       ("union", fun loc -> UNION loc);
       ("break", fun loc -> BREAK loc);
+      ("[[fallthrough]]", fun loc -> FALLTHROUGH loc);
+      ("[[__fallthrough__]]", fun loc -> FALLTHROUGH loc);
+      ("[[FALLTHROUGH]]", fun loc -> FALLTHROUGH loc); (* I suspect this one isn't needed *)
       ("continue", fun loc -> CONTINUE loc);
       ("goto", fun loc -> GOTO loc); 
       ("return", fun loc -> dbgToken (RETURN loc));
@@ -557,6 +560,9 @@ rule initial =
 |		octnum			{CST_INT (Lexing.lexeme lexbuf, currentLoc ())}
 |		intnum			{CST_INT (Lexing.lexeme lexbuf, currentLoc ())}
 |		"!quit!"		{EOF}
+|               "[[fallthrough]]"      {FALLTHROUGH (currentLoc ())}
+|               "[[__fallthrough__]]"  {FALLTHROUGH (currentLoc ())}
+|               "[[FALLTHROUGH]]"      {FALLTHROUGH (currentLoc ())}
 |		"..."			{ELLIPSIS}
 |		"+="			{PLUS_EQ}
 |		"-="			{MINUS_EQ}

--- a/src/frontc/cparser.mly
+++ b/src/frontc/cparser.mly
@@ -294,7 +294,8 @@ let transformOffsetOf (speclist, dtype) member =
 %token RPAREN 
 %token<Cabs.cabsloc> LPAREN RBRACE
 %token<Cabs.cabsloc> LBRACE
-%token LBRACKET RBRACKET
+%token<Cabs.cabsloc> DOUBLE_LBRACKET LBRACKET
+%token RBRACKET
 %token COLON
 %token<Cabs.cabsloc> SEMICOLON
 %token COMMA ELLIPSIS QUEST
@@ -1116,6 +1117,9 @@ direct_decl: /* (* ISO 6.7.5 *) */
 |   LPAREN attributes declarator RPAREN
                                    { let (n,decl,al,loc) = $3 in
                                      (n, PARENTYPE($2,decl,al)) }
+|   direct_decl LBRACKET LBRACKET attr_list RBRACKET RBRACKET 
+                                   { let (n, decl) = $1 in
+                                     (n, ARRAY(decl, [("__attribute__", $4)], NOTHING)) }
 
 |   direct_decl LBRACKET attributes comma_expression_opt RBRACKET
                                    { let (n, decl) = $1 in
@@ -1353,6 +1357,8 @@ attribute_nocv:
 |   ATTRIBUTE_USED                      { ("__attribute__", 
                                              [ VARIABLE "used" ]), $1 }
 *)*/
+|   DOUBLE_LBRACKET attr_list_ne RBRACKET RBRACKET
+                                        {("__attribute__", $2), $1}
 |   DECLSPEC paren_attr_list_ne         { ("__declspec", $2), $1 }
 |   MSATTR                              { (fst $1, []), snd $1 }
                                         /* ISO 6.7.3 */
@@ -1380,6 +1386,8 @@ just_attribute:
     ATTRIBUTE LPAREN paren_attr_list RPAREN
                                         { ("__attribute__", $3) }
 |   DECLSPEC paren_attr_list_ne         { ("__declspec", $2) }
+|   DOUBLE_LBRACKET attr_list_ne RBRACKET RBRACKET
+                                        {("__attribute__", $2)}
 ;
 
 /* this can't be empty, b/c I folded that possibility into the calling

--- a/src/frontc/cparser.mly
+++ b/src/frontc/cparser.mly
@@ -300,7 +300,7 @@ let transformOffsetOf (speclist, dtype) member =
 %token<Cabs.cabsloc> SEMICOLON
 %token COMMA ELLIPSIS QUEST
 
-%token<Cabs.cabsloc> BREAK CONTINUE GOTO RETURN
+%token<Cabs.cabsloc> BREAK CONTINUE GOTO RETURN FALLTHROUGH
 %token<Cabs.cabsloc> SWITCH CASE DEFAULT
 %token<Cabs.cabsloc> WHILE DO FOR
 %token<Cabs.cabsloc> IF TRY EXCEPT FINALLY
@@ -913,6 +913,7 @@ statement:
 |   RETURN comma_expression SEMICOLON
 	                         {RETURN (smooth_expression (fst $2), (*handleLoc*) $1)}
 |   BREAK SEMICOLON     {BREAK ((*handleLoc*) $1)}
+|   FALLTHROUGH SEMICOLON {FALLTHROUGH ((*handleLoc*) $1)}
 |   CONTINUE SEMICOLON	 {CONTINUE ((*handleLoc*) $1)}
 |   GOTO IDENT SEMICOLON
 		                 {GOTO (fst $2, (*handleLoc*) $1)}

--- a/src/frontc/cprint.ml
+++ b/src/frontc/cprint.ml
@@ -622,6 +622,9 @@ and print_statement stat =
   | BREAK (loc)->
       setLoc(loc);
       print "break;"; new_line ()
+  | FALLTHROUGH (loc)->
+      setLoc(loc);
+      print "[[fallthrough]];"; new_line()
   | CONTINUE (loc) ->
       setLoc(loc);
       print "continue;"; new_line ()


### PR DESCRIPTION
There's such a thing as a ["fallthrough statement"](https://en.cppreference.com/w/cpp/language/attributes/fallthrough), which GNUTLS also uses. This implementation has a couple of issues so it's very much WIP...:

- [ ] It shouldn't prohibit the use of `[[fallthrough]]` as an attribute, which should be allowed too, but currently `[[fallthrough]]` must be a "fallthrough statement"
- [ ] It defines a couple of different forms, and I'm not sure they're all valid (`[[fallthrough]]`, `[[FALLTHROUGH]]`, `[[__fallthrough__]]`), so I need to revisit and remove the invalid forms

Bit of a strange one but GNUTLS wanted it. Progress progress.