### PR TITLE
Support `__builtin_rotate{left,right}{32,64}`

### DIFF
--- a/src/cil.ml
+++ b/src/cil.ml
@@ -3064,6 +3064,11 @@ let initGccBuiltins () : unit =
   H.add h "__builtin_coshf" (floatType, [ floatType ], false);
   H.add h "__builtin_coshl" (longDoubleType, [ longDoubleType ], false);
 
+  H.add h "__builtin_rotateleft32" (uintType, [uintType; uintType], false);
+  H.add h "__builtin_rotateright32" (uintType, [uintType; uintType], false);
+  H.add h "__builtin_rotateleft64" (ulongType, [ulongType; ulongType], false);
+  H.add h "__builtin_rotateright64" (ulongType, [ulongType; ulongType], false);
+
   H.add h "__builtin_clz" (intType, [ uintType ], false);
   H.add h "__builtin_clzl" (intType, [ ulongType ], false);
   H.add h "__builtin_clzll" (intType, [ ulongLongType ], false);


### PR DESCRIPTION
Adds support for a couple of builtins:

- `__builtin_rotateleft32`
- `__builtin_rotateright32`
- `__builtin_rotateleft64`
- `__builtin_rotateright64`