### PR TITLE
Mark `no_sanitize` as a function-only attribute

### DIFF
--- a/src/cil.ml
+++ b/src/cil.ml
@@ -1479,7 +1479,7 @@ let attributeHash: (string, attributeClass) H.t =
   List.iter (fun a -> H.add table a (AttrFunType false))
     [ "format"; "regparm"; "longcall"; 
       "noinline"; "always_inline"; "gnu_inline"; "leaf"; "cold"; "alloc_size";
-      "artificial"; "warn_unused_result"; "nonnull"; "pure";
+      "artificial"; "warn_unused_result"; "nonnull"; "pure"; "no_sanitize";
     ];
 
   List.iter (fun a -> H.add table a (AttrFunType true))


### PR DESCRIPTION
Fixes https://github.com/stephenrkell/liballocs/issues/152

Stephen notes in the above issue that it's maybe worth rethinking the logic around attribute placement --- for example, should we mark attributes as specific to functions or to e.g. types? --- this doesn't make any relevant changes but it's certainly something to think about.

I believe we can also mark attributes as specific to types (there's an `AttrType` list as well as `AttrFunType`) so perhaps the logic already exists? I haven't dug into this enough yet!