### PR TITLE
Revert "frontc: rough cut at grokking #defines available via -Wp,-dMD…

### DIFF
--- a/src/frontc/cabs.ml
+++ b/src/frontc/cabs.ml
@@ -186,7 +186,6 @@ and definition =
  | ONLYTYPEDEF of specifier * cabsloc
  | GLOBASM of string * cabsloc
  | PRAGMA of expression * cabsloc
- | MACDEF of string * string * cabsloc
  | LINKAGE of string * cabsloc * definition list (* extern "C" { ... } *)
  (* toplevel form transformer, from the first definition to the *)
  (* second group of definitions *)

--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -6313,6 +6313,7 @@ and doDecl (isglobal: bool) (isstmt: bool) : A.definition -> chunk = function
           in
           cabsPushGlobal (GPragma (a'', !currentLoc));
           empty
+
       | _ -> E.s (error "Too many attributes in pragma")
   end
   | A.TRANSFORMER (_, _, _) -> E.s (E.bug "TRANSFORMER in cabs2cil input")

--- a/src/frontc/cabshelper.ml
+++ b/src/frontc/cabshelper.ml
@@ -75,7 +75,6 @@ let get_definitionloc (d : definition) : cabsloc =
   | ONLYTYPEDEF(_, l) -> l
   | GLOBASM(_, l) -> l
   | PRAGMA(_, l) -> l
-  | MACDEF(_, _, l) -> l
   | TRANSFORMER(_, _, l) -> l
   | EXPRTRANSFORMER(_, _, l) -> l
   | LINKAGE (_, l, _) -> l

--- a/src/frontc/cabsvisit.ml
+++ b/src/frontc/cabsvisit.ml
@@ -326,8 +326,7 @@ and childrenDefinition vis d =
   | PRAGMA (e, l) ->
       let e' = visitCabsExpression vis e in
       if e' != e then PRAGMA (e', l) else d
-  | MACDEF (ident, e, l) -> d
-  | LINKAGE (n, l, dl) -> 
+  | LINKAGE (n, l, dl) ->
       let dl' = mapNoCopyList (visitCabsDefinition vis) dl in
       if dl' != dl then LINKAGE (n, l, dl') else d
   

--- a/src/frontc/clexer.mll
+++ b/src/frontc/clexer.mll
@@ -433,9 +433,9 @@ let wstr_to_warray wstr =
   !res
 *)
 
-(* Pragmas and (if present) defines get explicit end-of-line tokens.
- * Elsewhere they are silently discarded as whitespace. *)
-let hashLine = ref false
+(* Pragmas get explicit end-of-line tokens.
+   Elsewhere they are silently discarded as whitespace. *)
+let pragmaLine = ref false
 
 }
 let decdigit = ['0'-'9']
@@ -483,9 +483,7 @@ let hexquad = hexdigit hexdigit hexdigit hexdigit
 let universal_escape = '\\' ('u' hexquad | 'U' hexquad hexquad)
 let ident = (letter|'_'|'$'|universal_escape)(letter|decdigit|'_'|'$'|universal_escape)*
 
-(* Pragmas that are not parsed by CIL.  We lex them as PRAGMA_UNPARSED tokens.
- * (The pragmas that we do parse have to look, roughly, like an attribute
- * invocation, possibly with a trailing semicolon; see PRAGMA in cparser.mly.) *)
+(* Pragmas that are not parsed by CIL.  We lex them as PRAGMA_LINE tokens *)
 let no_parse_pragma =
                "warning" | "GCC" | "STDC" | "clang"
              (* Solaris-style pragmas:  *)
@@ -511,10 +509,10 @@ rule initial =
                                            }
 |		blank			{ addWhite lexbuf; initial lexbuf}
 |               '\n'                    { E.newline ();
-                                          if !hashLine then
+                                          if !pragmaLine then
                                             begin
-                                              hashLine := false;
-                                              HASH_EOL
+                                              pragmaLine := false;
+                                              PRAGMA_EOL
                                             end
                                           else begin
                                             addWhite lexbuf;
@@ -687,12 +685,9 @@ and hash = parse
                    we parse them as a whole line. *)
 | "pragma" blank (no_parse_pragma as pragmaName)
                 { let here = currentLoc () in
-                  PRAGMA_UNPARSED (pragmaName ^ pragma lexbuf, here)
+                  PRAGMA_LINE (pragmaName ^ pragma lexbuf, here)
                 }
-| "pragma"      { hashLine := true; PRAGMA (currentLoc ()) }
-| "define" blank (ident as macName) {  let here = currentLoc () in
-                  DEFINE_UNPARSED (macName, macdef lexbuf, here) }
-
+| "pragma"      { pragmaLine := true; PRAGMA (currentLoc ()) }
 | _	        { addWhite lexbuf; endline lexbuf}
 
 and file lineno =  parse
@@ -712,12 +707,8 @@ and endline = parse
 
 and pragma = parse
    '\n'                 { E.newline (); "" }
-|   _                   { let cur = Lexing.lexeme lexbuf in 
-                          cur ^ (pragma lexbuf) }  
-and macdef = parse
-   '\n'                 { E.newline (); "" }
-|   _                   { let cur = Lexing.lexeme lexbuf in 
-                          cur ^ (macdef lexbuf) }  
+|   _                   { let cur = Lexing.lexeme lexbuf in
+                          cur ^ (pragma lexbuf) }
 
 and str = parse
         '"'             {[]} (* no nul terminiation in CST_STRING '"' *)

--- a/src/frontc/cparser.mly
+++ b/src/frontc/cparser.mly
@@ -312,13 +312,9 @@ let transformOffsetOf (speclist, dtype) member =
 %token BLOCKATTRIBUTE
 %token<Cabs.cabsloc> BUILTIN_TYPES_COMPAT BUILTIN_OFFSETOF BUILTIN_CONVVEC
 %token<Cabs.cabsloc> DECLSPEC
-%token<string * Cabs.cabsloc> MSASM MSATTR
-%token<string * Cabs.cabsloc> HASH_LINE
-%token<string * Cabs.cabsloc> PRAGMA_UNPARSED
-%token<string * string * Cabs.cabsloc> DEFINE_UNPARSED /*(* srk: merge these? *)*/
+%token<string * Cabs.cabsloc> PRAGMA_LINE
 %token<Cabs.cabsloc> PRAGMA
-%token HASH_EOL
-%token<string * string * Cabs.cabsloc> MACRO_DEF /*(* srk: or these? *)*/
+%token PRAGMA_EOL
 
 /* sm: cabs tree transformation specification keywords */
 %token<Cabs.cabsloc> AT_TRANSFORM AT_TRANSFORMEXPR AT_SPECIFIER AT_EXPR
@@ -433,7 +429,6 @@ global:
 | ASM LPAREN const_raw_string RPAREN SEMICOLON
                                         { GLOBASM (fst $3, (*handleLoc*) $1) }
 | pragma                                { $1 }
-| define                                { $1 }
 /* (* Old-style function prototype. This should be somewhere else, like in
       "declaration". For now we keep it at global scope only because in local
       scope it looks too much like a function call  *) */
@@ -1487,27 +1482,19 @@ just_attributes:
 ;
 
 /** (* PRAGMAS and ATTRIBUTES *) ***/
-pragma: 
-| PRAGMA attr HASH_EOL		{ PRAGMA ($2, $1) }
-| PRAGMA attr SEMICOLON HASH_EOL	{ PRAGMA ($2, $1) }
-| PRAGMA_UNPARSED                           { PRAGMA (VARIABLE (fst $1), 
+pragma:
+| PRAGMA attr PRAGMA_EOL		{ PRAGMA ($2, $1) }
+| PRAGMA attr SEMICOLON PRAGMA_EOL	{ PRAGMA ($2, $1) }
+| PRAGMA_LINE                           { PRAGMA (VARIABLE (fst $1),
                                                   snd $1) }
 ;
 
-/** (* DEFINEs... what are the semantic attributes of DEFINE_UNPARSED?
-       For PRAGMA_UNPARSED we have only $1, i.e. the PRAGMA_UNPARSED token
-       itself, which gets annotated with a pair (pragmaName ^ pragma lexbuf, here).
-       So fst $1 is the pragmaName plus the stuff that gets appended, and
-          snd $1 is the location.
-       Since DEFINE_UNPARSED gets a triple, we can't use fst/snd.... *) ***/
-define: 
-| DEFINE_UNPARSED { MACDEF ((let (f, _, _) = $1 in f), (let (_, s, _) = $1 in s), (let (_, _, t) = $1 in t)) }
-;
-
-/* (* We want to allow certain strange things that occur in pragmas, so we 
-    * cannot use directly the language of expressions *) */ 
-primary_attr: 
-    IDENT				{ VARIABLE (fst $1) }
+/* (* We want to allow certain strange things that occur in pragmas, so we
+      cannot use directly the language of expressions *) */
+primary_attr:
+    IDENT				                        { VARIABLE (fst $1) }
+    /* (* This is just so code such as __attribute(_NoReturn) is not rejected, which may arise when combining GCC noreturn attribute and including C11 stdnoreturn.h *) */
+|   NORETURN                            { VARIABLE ("__noreturn__") }
     /*(* The NAMED_TYPE here creates conflicts with IDENT *)*/
 |   NAMED_TYPE				{ VARIABLE (fst $1) }
 |   LPAREN attr RPAREN                  { $2 }

--- a/src/frontc/cprint.ml
+++ b/src/frontc/cprint.ml
@@ -931,11 +931,6 @@ and print_def def =
       end;
       print ");";
 
-  | MACDEF (name, body, loc) ->
-      setLoc(loc);
-      print ("#define " ^ name ^ " " ^ body);
-      force_new_line ()
-
 (* sm: print a comment if the printComments flag is set *)
 and comprint (str : string) : unit =
 begin


### PR DESCRIPTION
…, perhaps to replace Machdep"

This reverts commit 7ff39f168629c01e19e50d4b9120407f1a5ec257.

This commit breaks macro definition handling, due to the missing MACDEF case in cabs2cil.ml `doDecl`. 

Minimal example:

```
$ cilly -g3 empty.c
:-1: Error: unexpected form of declaration
Fatal error: exception GoblintCil__Errormsg.Error
```

where `empty.c` is an empty file.